### PR TITLE
Fixed problem with method having **kwargs in function signature.

### DIFF
--- a/pytest_when/when.py
+++ b/pytest_when/when.py
@@ -66,6 +66,7 @@ def create_call_key(
     kwargs_key: _CallKey = tuple(
         (k, get_from_kwargs_or_default(k))
         for k in tuple(original_params)[len(args) :]
+        if k != "kwargs"
     )
     return args_key + kwargs_key
 

--- a/tests/resources/example_module.py
+++ b/tests/resources/example_module.py
@@ -6,3 +6,7 @@ def some_normal_function(
     kwarg2: str,
 ) -> str:
     return "Not mocked"
+
+
+def arg_kwarg_function(*args, **kwargs):
+    return "Not mocked"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -286,3 +286,13 @@ def test_should_work_with_default_params_in_functions(when):
         == "Not mocked"
     )
     patched_klass.assert_called()
+
+
+def test_should_pass_method_with_args_and_kwargs(when):
+    when(example_module, "arg_kwarg_function").called_with(
+        "hello"
+    ).then_return("Mocked")
+
+    assert example_module.arg_kwarg_function("hello") == "Mocked"
+
+    assert example_module.arg_kwarg_function("hi") == "Not mocked"


### PR DESCRIPTION
It seems to me, that main problem is that if kwargs is used in function signature, than it is trying to find named argument kwargs instead of looking into kwargs. 
So ommiting kwargs from looking key should fix the issue.

Fixes #5 