### PR TITLE
Add more triggers for CI Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - '*'
+      - '**/*'
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
       - '*'
     tags:
       - '*'
+  pull_request:
+      branches:
+        - '*'
 
 name: Test Action
 


### PR DESCRIPTION
Fixing two issues with CI launch:

- When someone else forks the repo and create PR, action is not test action is not launched in your repo.
- When someone creates branch with / in name, like feature/something, wildcard '*' does not trigger, '**/*' is needed instead.